### PR TITLE
[Refactor] redis 책임 MongoDB 위임을 통한 참여자 현황 관리

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.springframework.boot:spring-boot-starter-websocket'
     implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
     testImplementation 'org.springframework.security:spring-security-test'
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/example/chatserverparticipant/domain/document/ChatParticipant.java
+++ b/src/main/java/com/example/chatserverparticipant/domain/document/ChatParticipant.java
@@ -1,0 +1,46 @@
+package com.example.chatserverparticipant.domain.document;
+
+import lombok.Data;
+import lombok.Getter;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.util.Map;
+
+@Data
+@Getter
+@Document(collection = "participants")
+public class ChatParticipant {
+
+    @Id
+    private String id; // MongoDB 기본 키
+
+    private String chatId;
+
+    private Map<String, Boolean> participant;
+
+    /**
+     * 생성자
+     * @param email
+     * 처음 생성 당시에는 구독하면서 읽을 테니 true 처리
+     */
+    public ChatParticipant(String email) {
+        this.participant.put(email, true);
+    }
+
+    /**
+     * @param email
+     * 접속만 끊기
+     */
+    public void nonParticipant(String email) {
+        this.participant.put(email, false);
+    }
+
+    /**
+     * @param email
+     * 채팅방 퇴장
+     */
+    public void exit(String email) {
+        this.participant.remove(email);
+    }
+}

--- a/src/main/java/com/example/chatserverparticipant/domain/document/ChatParticipant.java
+++ b/src/main/java/com/example/chatserverparticipant/domain/document/ChatParticipant.java
@@ -39,7 +39,7 @@ public class ChatParticipant {
      * @param email
      * 채팅방 퇴장
      */
-    public void exit(String email) {
+    public void leave(String email) {
         this.participant.remove(email);
     }
 }

--- a/src/main/java/com/example/chatserverparticipant/domain/document/ChatParticipant.java
+++ b/src/main/java/com/example/chatserverparticipant/domain/document/ChatParticipant.java
@@ -3,6 +3,7 @@ package com.example.chatserverparticipant.domain.document;
 import lombok.Data;
 import lombok.Getter;
 import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.index.Indexed;
 import org.springframework.data.mongodb.core.mapping.Document;
 
 import java.util.Map;
@@ -15,6 +16,7 @@ public class ChatParticipant {
     @Id
     private String id; // MongoDB 기본 키
 
+    @Indexed(unique = true)
     private String chatId;
 
     private Map<String, Boolean> participant;
@@ -24,7 +26,7 @@ public class ChatParticipant {
      * 접속 처리
      */
     public void participant(String email) {
-        this.participant.put(email, true);
+        this.participant.put(sanitizeEmail(email), true);
     }
 
     /**
@@ -32,7 +34,7 @@ public class ChatParticipant {
      * 접속만 끊기
      */
     public void nonParticipant(String email) {
-        this.participant.put(email, false);
+        this.participant.put(sanitizeEmail(email), false);
     }
 
     /**
@@ -40,6 +42,11 @@ public class ChatParticipant {
      * 채팅방 퇴장
      */
     public void leave(String email) {
-        this.participant.remove(email);
+        this.participant.remove(sanitizeEmail(email));
+    }
+
+    // map 구조의 키에 dot(.)이 붙어있으면 안되는디... 이메일은 닷이 당연히 붙잖아.. 닷컴
+    private String sanitizeEmail(String email) {
+        return email.replace(".", "-dot-");
     }
 }

--- a/src/main/java/com/example/chatserverparticipant/domain/document/ChatParticipant.java
+++ b/src/main/java/com/example/chatserverparticipant/domain/document/ChatParticipant.java
@@ -20,11 +20,10 @@ public class ChatParticipant {
     private Map<String, Boolean> participant;
 
     /**
-     * 생성자
      * @param email
-     * 처음 생성 당시에는 구독하면서 읽을 테니 true 처리
+     * 접속 처리
      */
-    public ChatParticipant(String email) {
+    public void participant(String email) {
         this.participant.put(email, true);
     }
 

--- a/src/main/java/com/example/chatserverparticipant/domain/dto/ChatUserReadDTO.java
+++ b/src/main/java/com/example/chatserverparticipant/domain/dto/ChatUserReadDTO.java
@@ -1,0 +1,4 @@
+package com.example.chatserverparticipant.domain.dto;
+
+public record ChatUserReadDTO(String chatId, String email, Boolean read, Boolean leave) {
+}

--- a/src/main/java/com/example/chatserverparticipant/domain/repository/ChatParticipantRepository.java
+++ b/src/main/java/com/example/chatserverparticipant/domain/repository/ChatParticipantRepository.java
@@ -4,6 +4,10 @@ import com.example.chatserverparticipant.domain.document.ChatParticipant;
 import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
-public interface ParticipantRepository extends MongoRepository<ChatParticipant, String> {
+public interface ChatParticipantRepository extends MongoRepository<ChatParticipant, String> {
+
+    Optional<ChatParticipant> findByChatId(String chatId);
 }

--- a/src/main/java/com/example/chatserverparticipant/domain/repository/ParticipantRepository.java
+++ b/src/main/java/com/example/chatserverparticipant/domain/repository/ParticipantRepository.java
@@ -1,0 +1,9 @@
+package com.example.chatserverparticipant.domain.repository;
+
+import com.example.chatserverparticipant.domain.document.ChatParticipant;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ParticipantRepository extends MongoRepository<ChatParticipant, String> {
+}

--- a/src/main/java/com/example/chatserverparticipant/domain/service/ChatParticipantService.java
+++ b/src/main/java/com/example/chatserverparticipant/domain/service/ChatParticipantService.java
@@ -1,0 +1,66 @@
+package com.example.chatserverparticipant.domain.service;
+
+import com.example.chatserverparticipant.domain.document.ChatParticipant;
+import com.example.chatserverparticipant.domain.dto.ChatUserReadDTO;
+import com.example.chatserverparticipant.domain.dto.UserReadDTO;
+import com.example.chatserverparticipant.domain.repository.ChatParticipantRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+@Slf4j(topic = "MONGODB_PARTICIPANT_SERVICE")
+@Service
+@RequiredArgsConstructor
+public class ChatParticipantService {
+
+    private final ChatParticipantRepository chatParticipantRepository;
+
+    // 채팅방 읽음
+    public void read(ChatUserReadDTO chatUserReadDTO) {
+        ChatParticipant chatParticipant = findChatParticipant(chatUserReadDTO.chatId());
+        chatParticipant.getParticipant().put(
+                chatUserReadDTO.email(), true
+        );
+
+        chatParticipantRepository.save(chatParticipant);
+    }
+
+    // 채팅방 안 읽음
+    public void exit(ChatUserReadDTO chatUserReadDTO) {
+        ChatParticipant chatParticipant = findChatParticipant(chatUserReadDTO.chatId());
+        chatParticipant.getParticipant().put(
+                chatUserReadDTO.email(), false
+        );
+
+        chatParticipantRepository.save(chatParticipant);
+    }
+
+    // 채팅방 구독 종료
+    public void leave(ChatUserReadDTO chatUserReadDTO) {
+        ChatParticipant chatParticipant = findChatParticipant(chatUserReadDTO.chatId());
+        chatParticipant.getParticipant().remove(chatUserReadDTO.email());
+
+        chatParticipantRepository.save(chatParticipant);
+    }
+
+    // 채팅방 리스트 반환하기
+    public List<UserReadDTO> getParticipantsList(ChatUserReadDTO chatUserReadDTO) {
+        ChatParticipant chatParticipant = findChatParticipant(chatUserReadDTO.chatId());
+        Map<String, Boolean> participants = chatParticipant.getParticipant();
+
+        return participants.entrySet()
+                .stream()
+                .map(e -> new UserReadDTO(e.getKey(), e.getValue())).toList();
+    }
+
+    private ChatParticipant findChatParticipant(String chatId) {
+        return chatParticipantRepository.findById(chatId).orElseThrow(
+                () -> new IllegalArgumentException("Chat participant not found")
+        );
+    }
+
+}

--- a/src/main/java/com/example/chatserverparticipant/domain/service/ChatParticipantService.java
+++ b/src/main/java/com/example/chatserverparticipant/domain/service/ChatParticipantService.java
@@ -21,11 +21,14 @@ public class ChatParticipantService {
     public void service(ChatUserReadDTO chatUserReadDTO) {
         // 채팅방을 떠났는가?(구독 종료)
         if (chatUserReadDTO.leave()) {
+            log.info("채팅방 구독 종료");
             leave(chatUserReadDTO);
         } else {
             if (chatUserReadDTO.read()) {
+                log.info("채팅방에 접속");
                 read(chatUserReadDTO);
             } else {
+                log.info("채팅방 접속 종료");
                 exit(chatUserReadDTO);
             }
         }
@@ -38,12 +41,19 @@ public class ChatParticipantService {
 
         return participants.entrySet()
                 .stream()
-                .map(e -> new UserReadDTO(e.getKey(), e.getValue())).toList();
+                .map(e -> new UserReadDTO(
+                        e.getKey().replace("-dot-", "."),
+                        e.getValue()))
+                .toList();
     }
 
     // 채팅방 읽음
     private void read(ChatUserReadDTO chatUserReadDTO) {
+        log.info("디티오: {}", chatUserReadDTO);
+        log.info("채팅방 아이디: {}", chatUserReadDTO.chatId());
+
         ChatParticipant chatParticipant = findChatParticipant(chatUserReadDTO.chatId());
+        log.info("서비스 로직에서 채팅방 도큐먼트 찾기: {}", chatParticipant);
         chatParticipant.participant(chatUserReadDTO.email());
 
         chatParticipantRepository.save(chatParticipant);
@@ -66,6 +76,8 @@ public class ChatParticipantService {
     }
 
     private ChatParticipant findChatParticipant(String chatId) {
+        log.info("한번 다 찾아보자: {}", chatParticipantRepository.findAll());
+
         return chatParticipantRepository.findByChatId(chatId).orElseThrow(
                 () -> new IllegalArgumentException("Chat participant not found")
         );

--- a/src/main/java/com/example/chatserverparticipant/domain/service/ChatParticipantService.java
+++ b/src/main/java/com/example/chatserverparticipant/domain/service/ChatParticipantService.java
@@ -8,7 +8,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -19,32 +18,17 @@ public class ChatParticipantService {
 
     private final ChatParticipantRepository chatParticipantRepository;
 
-    // 채팅방 읽음
-    public void read(ChatUserReadDTO chatUserReadDTO) {
-        ChatParticipant chatParticipant = findChatParticipant(chatUserReadDTO.chatId());
-        chatParticipant.getParticipant().put(
-                chatUserReadDTO.email(), true
-        );
-
-        chatParticipantRepository.save(chatParticipant);
-    }
-
-    // 채팅방 안 읽음
-    public void exit(ChatUserReadDTO chatUserReadDTO) {
-        ChatParticipant chatParticipant = findChatParticipant(chatUserReadDTO.chatId());
-        chatParticipant.getParticipant().put(
-                chatUserReadDTO.email(), false
-        );
-
-        chatParticipantRepository.save(chatParticipant);
-    }
-
-    // 채팅방 구독 종료
-    public void leave(ChatUserReadDTO chatUserReadDTO) {
-        ChatParticipant chatParticipant = findChatParticipant(chatUserReadDTO.chatId());
-        chatParticipant.getParticipant().remove(chatUserReadDTO.email());
-
-        chatParticipantRepository.save(chatParticipant);
+    public void service(ChatUserReadDTO chatUserReadDTO) {
+        // 채팅방을 떠났는가?(구독 종료)
+        if (chatUserReadDTO.leave()) {
+            leave(chatUserReadDTO);
+        } else {
+            if (chatUserReadDTO.read()) {
+                read(chatUserReadDTO);
+            } else {
+                exit(chatUserReadDTO);
+            }
+        }
     }
 
     // 채팅방 리스트 반환하기
@@ -55,6 +39,30 @@ public class ChatParticipantService {
         return participants.entrySet()
                 .stream()
                 .map(e -> new UserReadDTO(e.getKey(), e.getValue())).toList();
+    }
+
+    // 채팅방 읽음
+    private void read(ChatUserReadDTO chatUserReadDTO) {
+        ChatParticipant chatParticipant = findChatParticipant(chatUserReadDTO.chatId());
+        chatParticipant.participant(chatUserReadDTO.email());
+
+        chatParticipantRepository.save(chatParticipant);
+    }
+
+    // 채팅방 안 읽음
+    private void exit(ChatUserReadDTO chatUserReadDTO) {
+        ChatParticipant chatParticipant = findChatParticipant(chatUserReadDTO.chatId());
+        chatParticipant.nonParticipant(chatUserReadDTO.email());
+
+        chatParticipantRepository.save(chatParticipant);
+    }
+
+    // 채팅방 구독 종료
+    private void leave(ChatUserReadDTO chatUserReadDTO) {
+        ChatParticipant chatParticipant = findChatParticipant(chatUserReadDTO.chatId());
+        chatParticipant.leave(chatUserReadDTO.email());
+
+        chatParticipantRepository.save(chatParticipant);
     }
 
     private ChatParticipant findChatParticipant(String chatId) {

--- a/src/main/java/com/example/chatserverparticipant/domain/service/ChatParticipantService.java
+++ b/src/main/java/com/example/chatserverparticipant/domain/service/ChatParticipantService.java
@@ -58,7 +58,7 @@ public class ChatParticipantService {
     }
 
     private ChatParticipant findChatParticipant(String chatId) {
-        return chatParticipantRepository.findById(chatId).orElseThrow(
+        return chatParticipantRepository.findByChatId(chatId).orElseThrow(
                 () -> new IllegalArgumentException("Chat participant not found")
         );
     }

--- a/src/main/java/com/example/chatserverparticipant/global/config/RedisConfig.java
+++ b/src/main/java/com/example/chatserverparticipant/global/config/RedisConfig.java
@@ -63,40 +63,40 @@ public class RedisConfig {
         return getStringChatUserReadDTOTemplate(redisConnectionFactory);
     }
 
-    // 채팅창의 접속자 인원 관리(초기 데이터용)
-    @Bean(name = "participatedTemplate")
-    public RedisTemplate<String, Boolean> participatedTemplate(RedisConnectionFactory redisConnectionFactory) {
-        return getStringBooleanTemplate(redisConnectionFactory);
-    }
-
-    private RedisTemplate<String, String> getStringStringRedisTemplate(RedisConnectionFactory redisConnectionFactory) {
-        RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();
-        redisTemplate.setConnectionFactory(redisConnectionFactory);
-
-        redisTemplate.setKeySerializer(new StringRedisSerializer());
-        redisTemplate.setValueSerializer(new StringRedisSerializer());
-
-        redisTemplate.setHashKeySerializer(new StringRedisSerializer());
-        redisTemplate.setHashValueSerializer(new StringRedisSerializer());
-
-        return redisTemplate;
-    }
-
-    private RedisTemplate<String, Boolean> getStringBooleanTemplate(RedisConnectionFactory redisConnectionFactory) {
-        RedisTemplate<String, Boolean> redisTemplate = new RedisTemplate<>();
-        redisTemplate.setConnectionFactory(redisConnectionFactory);
-
-        // 키와 해시 키는 String으로 설정
-        redisTemplate.setKeySerializer(new StringRedisSerializer());
-        redisTemplate.setHashKeySerializer(new StringRedisSerializer());
-
-        // 해시 값은 Boolean으로 설정
-        redisTemplate.setHashValueSerializer(new Jackson2JsonRedisSerializer<>(Boolean.class));
-        // 값을 Boolean으로 설정
-        redisTemplate.setValueSerializer(new Jackson2JsonRedisSerializer<>(Boolean.class));
-
-        return redisTemplate;
-    }
+//    // 채팅창의 접속자 인원 관리(초기 데이터용)
+//    @Bean(name = "participatedTemplate")
+//    public RedisTemplate<String, Boolean> participatedTemplate(RedisConnectionFactory redisConnectionFactory) {
+//        return getStringBooleanTemplate(redisConnectionFactory);
+//    }
+//
+//    private RedisTemplate<String, String> getStringStringRedisTemplate(RedisConnectionFactory redisConnectionFactory) {
+//        RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();
+//        redisTemplate.setConnectionFactory(redisConnectionFactory);
+//
+//        redisTemplate.setKeySerializer(new StringRedisSerializer());
+//        redisTemplate.setValueSerializer(new StringRedisSerializer());
+//
+//        redisTemplate.setHashKeySerializer(new StringRedisSerializer());
+//        redisTemplate.setHashValueSerializer(new StringRedisSerializer());
+//
+//        return redisTemplate;
+//    }
+//
+//    private RedisTemplate<String, Boolean> getStringBooleanTemplate(RedisConnectionFactory redisConnectionFactory) {
+//        RedisTemplate<String, Boolean> redisTemplate = new RedisTemplate<>();
+//        redisTemplate.setConnectionFactory(redisConnectionFactory);
+//
+//        // 키와 해시 키는 String으로 설정
+//        redisTemplate.setKeySerializer(new StringRedisSerializer());
+//        redisTemplate.setHashKeySerializer(new StringRedisSerializer());
+//
+//        // 해시 값은 Boolean으로 설정
+//        redisTemplate.setHashValueSerializer(new Jackson2JsonRedisSerializer<>(Boolean.class));
+//        // 값을 Boolean으로 설정
+//        redisTemplate.setValueSerializer(new Jackson2JsonRedisSerializer<>(Boolean.class));
+//
+//        return redisTemplate;
+//    }
 
     private RedisTemplate<String, ChatUserReadDTO> getStringChatUserReadDTOTemplate(RedisConnectionFactory redisConnectionFactory) {
         RedisTemplate<String, ChatUserReadDTO> redisTemplate = new RedisTemplate<>();

--- a/src/main/java/com/example/chatserverparticipant/global/config/RedisConfig.java
+++ b/src/main/java/com/example/chatserverparticipant/global/config/RedisConfig.java
@@ -1,5 +1,6 @@
 package com.example.chatserverparticipant.global.config;
 
+import com.example.chatserverparticipant.domain.dto.ChatUserReadDTO;
 import com.example.chatserverparticipant.global.redis.RedisMessageListenerService;
 import io.lettuce.core.ClientOptions;
 import io.lettuce.core.SocketOptions;
@@ -58,8 +59,8 @@ public class RedisConfig {
     }
 
     @Bean(name = "pubSubTemplate")
-    public RedisTemplate<String, String> pubSubTemplate(RedisConnectionFactory redisConnectionFactory) {
-        return getStringStringRedisTemplate(redisConnectionFactory);
+    public RedisTemplate<String, ChatUserReadDTO> pubSubTemplate(RedisConnectionFactory redisConnectionFactory) {
+        return getStringChatUserReadDTOTemplate(redisConnectionFactory);
     }
 
     // 채팅창의 접속자 인원 관리(초기 데이터용)
@@ -93,6 +94,22 @@ public class RedisConfig {
         redisTemplate.setHashValueSerializer(new Jackson2JsonRedisSerializer<>(Boolean.class));
         // 값을 Boolean으로 설정
         redisTemplate.setValueSerializer(new Jackson2JsonRedisSerializer<>(Boolean.class));
+
+        return redisTemplate;
+    }
+
+    private RedisTemplate<String, ChatUserReadDTO> getStringChatUserReadDTOTemplate(RedisConnectionFactory redisConnectionFactory) {
+        RedisTemplate<String, ChatUserReadDTO> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory);
+
+        // 키와 해시 키는 String으로 설정
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setHashKeySerializer(new StringRedisSerializer());
+
+        // 해시 값은 Boolean으로 설정
+        redisTemplate.setHashValueSerializer(new Jackson2JsonRedisSerializer<>(ChatUserReadDTO.class));
+        // 값을 Boolean으로 설정
+        redisTemplate.setValueSerializer(new Jackson2JsonRedisSerializer<>(ChatUserReadDTO.class));
 
         return redisTemplate;
     }

--- a/src/main/java/com/example/chatserverparticipant/global/redis/RedisMessageListenerService.java
+++ b/src/main/java/com/example/chatserverparticipant/global/redis/RedisMessageListenerService.java
@@ -35,14 +35,13 @@ public class RedisMessageListenerService implements MessageListener {
         String body = new String(message.getBody());
 
         log.info("채널 확인: {} // 파싱: {}", channel, id);
-        log.info("날 것 그대로의 메세지: " + body);
 
         try {
             // JSON 파싱
             ChatUserReadDTO dto = new ObjectMapper().readValue(body, ChatUserReadDTO.class);
             log.info("레코드 파싱: {}", dto.toString());
 
-            List<UserReadDTO> data = new ObjectMapper().readValue(body, new TypeReference<List<UserReadDTO>>() {});
+            List<UserReadDTO> data = chatParticipantService.getParticipantsList(dto);
             log.info("파싱: {}", data.stream().map(e -> e.getEmail() + ": " + e.getIsRead()).toList());
 
             if (eventQueueService.isSubscriptionComplete(id)) {

--- a/src/main/java/com/example/chatserverparticipant/global/redis/RedisMessageListenerService.java
+++ b/src/main/java/com/example/chatserverparticipant/global/redis/RedisMessageListenerService.java
@@ -40,6 +40,7 @@ public class RedisMessageListenerService implements MessageListener {
             // JSON 파싱
             ChatUserReadDTO dto = new ObjectMapper().readValue(body, ChatUserReadDTO.class);
             log.info("레코드 파싱: {}", dto.toString());
+            chatParticipantService.service(dto); // 도큐먼트 업데이트 처리
 
             List<UserReadDTO> data = chatParticipantService.getParticipantsList(dto);
             log.info("파싱: {}", data.stream().map(e -> e.getEmail() + ": " + e.getIsRead()).toList());

--- a/src/main/java/com/example/chatserverparticipant/global/redis/RedisMessageListenerService.java
+++ b/src/main/java/com/example/chatserverparticipant/global/redis/RedisMessageListenerService.java
@@ -1,6 +1,8 @@
 package com.example.chatserverparticipant.global.redis;
 
+import com.example.chatserverparticipant.domain.dto.ChatUserReadDTO;
 import com.example.chatserverparticipant.domain.dto.UserReadDTO;
+import com.example.chatserverparticipant.domain.service.ChatParticipantService;
 import com.example.chatserverparticipant.domain.service.EventQueueService;
 import com.example.chatserverparticipant.global.facade.DistributedLockFacade;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -21,6 +23,8 @@ import java.util.List;
 public class RedisMessageListenerService implements MessageListener {
 
     private final EventQueueService eventQueueService;
+    private final ChatParticipantService chatParticipantService;
+
     private final SimpMessageSendingOperations messagingTemplate;
 
     @Override
@@ -35,6 +39,9 @@ public class RedisMessageListenerService implements MessageListener {
 
         try {
             // JSON 파싱
+            ChatUserReadDTO dto = new ObjectMapper().readValue(body, ChatUserReadDTO.class);
+            log.info("레코드 파싱: {}", dto.toString());
+
             List<UserReadDTO> data = new ObjectMapper().readValue(body, new TypeReference<List<UserReadDTO>>() {});
             log.info("파싱: {}", data.stream().map(e -> e.getEmail() + ": " + e.getIsRead()).toList());
 


### PR DESCRIPTION
## Redis에 과하게 몰린 데이터 관리 책임 위임 처리 목적

<img width="499" alt="상당히 지저분, noSQL에 의존하는 엔티티 값들" src="https://github.com/user-attachments/assets/913bfd84-2a6a-475f-90ea-eba242110708">

- 위의 사진처럼, 참여자 관리, 채팅 구독 관리 및 접속 관리의 실시간 반영을 전부 redis에 위임한 구조
- 성능 상의 이점과 별개로 향후 데이터 관리에 있어 책임이 과도하게 분배됨

### redis vs MongoDB vs PostgreSQL

- 현재 프로젝트에서 채택하고 있는 데이터베이스는 총 3개
- 해당 리팩토링은, 실시간의 잦은 수정이 발생하는 채팅 접속자 현황 관리에 쓰임
- 저기서 입출력 조회 성능이 가장 빠른 것은 redis지만, 그래도 비교를 하자면

| **항목**              | **Redis**                                              | **MongoDB**                                          | **PostgreSQL**                                       |
|-----------------------|--------------------------------------------------------|------------------------------------------------------|------------------------------------------------------|
| **수정 속도**         | 매우 빠름 (메모리 기반)                                | 빠름 (유연한 스키마)                                 | 느릴 수 있음 (트랜잭션 오버헤드)                     |
| **데이터 영속성**     | 낮음 (스냅샷 및 AOF로 보완 가능)                       | 보통 (최근 트랜잭션 지원 강화)                       | 높음 (ACID 트랜잭션 완전 지원)                       |
| **트랜잭션 처리**     | 제한적 (단순 트랜잭션 처리만 가능)                     | 제한적 (복잡한 트랜잭션에서 성능 저하 가능)           | 우수 (복잡한 트랜잭션도 안전하게 처리 가능)          |
| **사용 시나리오**     | 캐싱, 세션 관리 등 일시적인 데이터 수정에 적합         | 비정형 데이터의 빠른 수정과 수평 확장이 필요한 경우 | 데이터 무결성과 일관성이 중요한 애플리케이션에 적합 |
| **확장성**            | 수평 확장 가능하나 메모리 제한                         | 수평 확장에 매우 적합                                 | 수직 확장에 적합                                      |
| **적합한 경우**       | 일시적 데이터, 매우 잦은 수정이 필요한 경우            | 유연한 데이터 구조, 비정형 데이터, 대규모 수정 작업  | 복잡한 트랜잭션 처리와 데이터 무결성이 중요한 경우  |


- redis보다는 다운그레이드지만, **구독**과 **접속**의 객체지향적 분류에 대해 생각해봤음
- 채팅창에 대한 구독은 메타데이터로 관리하고, 접속을 세부 데이터로 관리하는 것으로 생각함
- 구독이 전제되어야 접속이 가능하므로
- 하여, 메타데이터는 **PostgreSQL**로 **채팅방 인스턴스 위임**, 접속 관리 세부 데이터는 **mongoDB**로 **참여자 인스턴스 위임**

### 리팩토링 진행

- 기존 코드는, 메세징 인스턴스가 모든 것을 처리 후 넘겨주면, 참여자 인스턴스에서 단순히 내보내는 역할에 불과했음
- 메세징 인스턴스의 책임을 참여자 인스턴스로 옮기면서, MongoDB 기반으로 채팅방별 참여자 데이터 관리

```java
Data
@Getter
@Document(collection = "participants")
public class ChatParticipant {

    @Id
    private String id; // MongoDB 기본 키

    @Indexed(unique = true)
    private String chatId;

    private Map<String, Boolean> participant;
    
    // ...
```

- 메세징 인스턴스에서는 redis pub sub으로 전하면서 채팅방의 참여자 상황 업데이트 데이터 레코드를 보냄

```java
// message instance

@Slf4j(topic = "ChatParticipantsService")
@Service
@RequiredArgsConstructor
public class RedisParticipantsService {

    private final RedisTemplate<String, ChatUserReadDTO> pubSubTemplate;

    public void participate(String chatId, String email) {
        ChatUserReadDTO chatUserReadDTO = new ChatUserReadDTO(chatId, email, true, false);
        pubSubTemplate.convertAndSend(REDIS_CHAT_PREFIX + chatId, chatUserReadDTO);
    }

    public void leave(String chatId, String email) {
        ChatUserReadDTO chatUserReadDTO = new ChatUserReadDTO(chatId, email, false, true);
        pubSubTemplate.convertAndSend(REDIS_CHAT_PREFIX + chatId, chatUserReadDTO);
    }
}
```

- 받아낸 참여자 인스턴스에서 해당 DTO를 파싱해서 해당 참여자가 포함된 채팅방 도큐먼트의 필드 업데이트 처리

```java
// participant instance

    // 채팅방 리스트 반환하기
    public List<UserReadDTO> getParticipantsList(ChatUserReadDTO chatUserReadDTO) {
        ChatParticipant chatParticipant = findChatParticipant(chatUserReadDTO.chatId());
        Map<String, Boolean> participants = chatParticipant.getParticipant();

        return participants.entrySet()
                .stream()
                .map(e -> new UserReadDTO(
                        e.getKey().replace("-dot-", "."),
                        e.getValue()))
                .toList();
    }

    // 채팅방 읽음
    private void read(ChatUserReadDTO chatUserReadDTO) {
        log.info("디티오: {}", chatUserReadDTO);
        log.info("채팅방 아이디: {}", chatUserReadDTO.chatId());

        ChatParticipant chatParticipant = findChatParticipant(chatUserReadDTO.chatId());
        log.info("서비스 로직에서 채팅방 도큐먼트 찾기: {}", chatParticipant);
        chatParticipant.participant(chatUserReadDTO.email());

        chatParticipantRepository.save(chatParticipant);
    }

```

- 참고로, RDBMS 엔티티와 다르게 MongoDB 도큐먼트는 필드 업데이트 후, 도큐먼트 다시 저장 과정이 필요

<img width="499" alt="mongodb로 변환" src="https://github.com/user-attachments/assets/750269e1-c555-4044-9423-d5ebf0612365">
